### PR TITLE
Rename deb to apt-multi-iam-s3 from apt-transport-s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ src/*.o
 src/s3
 debian/compat
 debian/files
-debian/apt-transport-s3
-debian/apt-transport-s3.substvars
-debian/apt-transport-s3.debhelper.log
+debian/apt-multi-iam-s3
+debian/apt-multi-iam-s3.substvars
+debian/apt-multi-iam-s3.debhelper.log
 *~

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all:
 
 clean:
 	for d in $(DIRS); do (cd $$d; $(MAKE) clean); done;
-	rm -rf debian/apt-transport-s3*
+	rm -rf debian/apt-multi-iam-s3*
 
 deb:
 	dpkg-buildpackage -us -uc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# apt-s3
+# apt-multi-iam-s3
 
 Additional "s3" protocol for apt so you can host your giant apt repository in s3 on the cheap!
 
@@ -33,14 +33,14 @@ Simply upload all of your .deb packages and Packages.gz file into the s3 bucket 
 Before synchronization, you need a s3cmd tool installed and configured:
 
     [sudo] apt-get install s3cmd
-    
+
     s3cmd --configure
 
 To synchronize local repository to s3 as read-only, execute:
 
     s3cmd sync /srv/apt-repo-dir/dists s3://bucket_name
     s3cmd sync /srv/apt-repo-dir/pool s3://bucket_name
-    
+
 ## Using GPG keys
 
 If you're signing you repository with key, export it to server:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+apt-multi-iam-s3 (1.1.1ubuntu2) xenial; urgency=low
+
+  * Renamed to avoid collision with the apt-transport-s3 included in Xenial
+
+ -- Joe Block <joe.block@daqri.com>  Mon Jun  6 11:38:17 PDT 2016
+
 apt-transport-s3 (1.1.1ubuntu2) precise; urgency=low
 
   * Modified for company needs

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: apt-transport-s3
+Source: apt-multi-iam-s3
 Section: admin
 Priority: optional
 Maintainer: Jorge A Gallegos <kad@blegh.net>
@@ -6,11 +6,10 @@ Homepage: https://github.com/kyleshank/apt-s3
 Standards-Version: 3.7.3
 Build-Depends: debhelper (>= 5.0), libapt-pkg-dev (>= 0.7.23), cdbs, libcurl4-openssl-dev
 
-Package: apt-transport-s3
+Package: apt-multi-iam-s3
 Architecture: any
 Depends: ${shlibs:Depends}
 Description: an APT transport for communicating with Amazon S3
- This package contains the APT amazon s3 transport. It makes it possible to
- use
+ This package contains an APT amazon s3 transport that supports different IAM credentials for each s3-backed repository. It makes it possible to use
  'deb s3://AWS_ACCESS_ID:[AWS_SECRET_KEY]@s3.amazonaws.com/BUCKETNAME prod main'
  type lines in your sources.list file.

--- a/debian/rules
+++ b/debian/rules
@@ -6,14 +6,14 @@
 
 include /usr/share/cdbs/1/rules/debhelper.mk
 
-DEB_DIR=$(CURDIR)/debian/apt-transport-s3
+DEB_DIR=$(CURDIR)/debian/apt-multi-iam-s3
 
-#configure/apt-transport-s3::
+#configure/apt-multi-iam-s3::
 #	@echo "We don't really have a configure script"
 #
-build/apt-transport-s3::
+build/apt-multi-iam-s3::
 	$(MAKE) -f $(CURDIR)/Makefile
 
-install/apt-transport-s3::
+install/apt-multi-iam-s3::
 	@cp $(CURDIR)/src/s3 $(DEB_DIR)/usr/lib/apt/methods/
 


### PR DESCRIPTION
Xenial includes an S3 apt transport helper that only supports using one IAM credential for all your S3-backed apt repositories. This reduces the granularity of permissions you can apply to machines, and isn't acceptable in our security model.

I'm renaming the deb so that I can use it on Xenial machines without having a namespace collision with the naive upstream transport tool.

If you've got a better idea for coping with this, I'm open to suggestions.
